### PR TITLE
Fix bug in product retrieval

### DIFF
--- a/src/app/test/test.component.ts
+++ b/src/app/test/test.component.ts
@@ -24,7 +24,7 @@ ngOnInit(){
 getProducts():Array<Product>
 {
 debugger;
- return this.filterValue ? this.products.splice(1,3) : this.products
+ return this.filterValue ? this.products.slice(1,4) : this.products
 
 }
 


### PR DESCRIPTION
## Summary
- fix `getProducts` so it doesn't mutate the products array

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848728ca4108325872202553b4d38bf